### PR TITLE
Allow us to configure whether to start the https server

### DIFF
--- a/diyhu-beta/config.json
+++ b/diyhu-beta/config.json
@@ -29,16 +29,15 @@
 	"auto_uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {
-		"config_path": "/config/diyhue",
 		"mac": "XX:XX:XX:XX:XX",
 		"debug": false,
 		"deconz_ip": "",
-		"no_serve_https": "false"
+		"no_serve_https": false
 	},
 	"schema": {
-		"config_path": "str",
 		"mac": "str",
 		"debug": "bool",
-		"deconz_ip": "str"
+		"deconz_ip": "str",
+		"no_serve_https": "bool"		
 	}
 }

--- a/diyhu-beta/config.json
+++ b/diyhu-beta/config.json
@@ -29,12 +29,14 @@
 	"auto_uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {
+		"config_path": "/config/diyhue",
 		"mac": "XX:XX:XX:XX:XX",
 		"debug": false,
 		"deconz_ip": "",
 		"no_serve_https": false
 	},
 	"schema": {
+	        "config_path": "str",		
 		"mac": "str",
 		"debug": "bool",
 		"deconz_ip": "str",

--- a/diyhu-beta/config.json
+++ b/diyhu-beta/config.json
@@ -32,7 +32,8 @@
 		"config_path": "/config/diyhue",
 		"mac": "XX:XX:XX:XX:XX",
 		"debug": false,
-		"deconz_ip": ""
+		"deconz_ip": "",
+		"disable_https": "false"
 	},
 	"schema": {
 		"config_path": "str",

--- a/diyhu-beta/config.json
+++ b/diyhu-beta/config.json
@@ -33,7 +33,7 @@
 		"mac": "XX:XX:XX:XX:XX",
 		"debug": false,
 		"deconz_ip": "",
-		"disable_https": "false"
+		"no_serve_https": "false"
 	},
 	"schema": {
 		"config_path": "str",

--- a/diyhu-beta/rootfs/run.sh
+++ b/diyhu-beta/rootfs/run.sh
@@ -10,6 +10,10 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"
 fi
 
+if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
+    export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
+fi
+
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."
 else
@@ -19,4 +23,8 @@ fi
 
 echo "Your Architecture is $BUILD_ARCHI"
 
-python3 -u /opt/hue-emulator/HueEmulator3.py --docker
+if [ "$NO_SERVE_HTTPS" = "true" ] ; then
+    python3 -u /opt/hue-emulator/HueEmulator3.py --docker --no-serve-https
+else 
+    python3 -u /opt/hue-emulator/HueEmulator3.py --docker
+fi

--- a/diyhu-beta/rootfs/run.sh
+++ b/diyhu-beta/rootfs/run.sh
@@ -3,6 +3,7 @@
 CONFIG_PATH=/data/options.json
 
 export MAC="$(bashio::config 'mac')"
+export CONFIG_PATH="$(bashio::config 'config_path')"
 export DEBUG="$(bashio::config 'debug')"
 
 if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
@@ -10,8 +11,6 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
 fi
 
 export NO_SERVE_HTTPS="$(bashio::config 'no_serve_https')"
-
-CONFIG_PATH=/data/config/diyhue
 
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."

--- a/diyhu-beta/rootfs/run.sh
+++ b/diyhu-beta/rootfs/run.sh
@@ -3,16 +3,13 @@
 CONFIG_PATH=/data/options.json
 
 export MAC="$(bashio::config 'mac')"
-export CONFIG_PATH="$(bashio::config 'config_path')"
 export DEBUG="$(bashio::config 'debug')"
 
 if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"
 fi
 
-if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
-    export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
-fi
+export NO_SERVE_HTTPS="$(bashio::config 'no_serve_https')"
 
 CONFIG_PATH=/data/config/diyhue
 

--- a/diyhu-beta/rootfs/run.sh
+++ b/diyhu-beta/rootfs/run.sh
@@ -14,6 +14,8 @@ if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
     export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
 fi
 
+CONFIG_PATH=/data/config/diyhue
+
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."
 else

--- a/diyhue/config.json
+++ b/diyhue/config.json
@@ -1,6 +1,6 @@
 {
 	"name": "diyHue-beta",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"slug": "diyhue-beta",
 	"description": "Philips Hue Bridge Emulator BETA",
 	"webui": "http://[HOST]:[PORT:80]",
@@ -32,12 +32,14 @@
 		"config_path": "/config/diyhue",
 		"mac": "XX:XX:XX:XX:XX",
 		"debug": false,
-		"deconz_ip": ""
+		"deconz_ip": "",
+		"no_serve_https": false
 	},
 	"schema": {
 		"config_path": "str",
 		"mac": "str",
 		"debug": "bool",
-		"deconz_ip": "str"
+		"deconz_ip": "str",
+		"no_serve_https": "bool"
 	}
 }

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -12,6 +12,8 @@ fi
 
 if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
     export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
+else
+    export NO_SERVE_HTTPS="false"
 fi
 
 CONFIG_PATH=/data/config/diyhue
@@ -23,10 +25,13 @@ else
     echo "$CONFIG_PATH created."
 fi
 
+
 echo "Your Architecture is $BUILD_ARCHI"
 
 if [ "$NO_SERVE_HTTPS" = "true" ] ; then
+    echo "No serve HTTPS"
     python3 -u /opt/hue-emulator/HueEmulator3.py --docker --no-serve-https
 else 
+    echo "Serve HTTPS"
     python3 -u /opt/hue-emulator/HueEmulator3.py --docker
 fi

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -10,11 +10,7 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"
 fi
 
-if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
-    export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
-else
-    export NO_SERVE_HTTPS="false"
-fi
+export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
 
 CONFIG_PATH=/data/config/diyhue
 

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -10,6 +10,12 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"
 fi
 
+if [[ ! -z "$(bashio::config 'no-serve-https')" ]]; then
+    export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
+fi
+
+CONFIG_PATH=/data/config/diyhue
+
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."
 else
@@ -19,4 +25,8 @@ fi
 
 echo "Your Architecture is $BUILD_ARCHI"
 
-python3 -u /opt/hue-emulator/HueEmulator3.py --docker
+if [ "$NO_SERVE_HTTPS" = "true" ] ; then
+    python3 -u /opt/hue-emulator/HueEmulator3.py --docker --no-serve-https
+else 
+    python3 -u /opt/hue-emulator/HueEmulator3.py --docker
+fi

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -10,7 +10,7 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"
 fi
 
-export NO_SERVE_HTTPS="$(bashio::config 'no-serve-https')"
+export NO_SERVE_HTTPS="$(bashio::config 'no_serve_https')"
 
 CONFIG_PATH=/data/config/diyhue
 

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -3,6 +3,7 @@
 CONFIG_PATH=/data/options.json
 
 export MAC="$(bashio::config 'mac')"
+export CONFIG_PATH="$(bashio::config 'config_path')"
 export DEBUG="$(bashio::config 'debug')"
 
 if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
@@ -10,9 +11,6 @@ if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
 fi
 
 export NO_SERVE_HTTPS="$(bashio::config 'no_serve_https')"
-
-CONFIG_PATH=/data/config/diyhue
-
 
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -3,7 +3,6 @@
 CONFIG_PATH=/data/options.json
 
 export MAC="$(bashio::config 'mac')"
-export CONFIG_PATH="$(bashio::config 'config_path')"
 export DEBUG="$(bashio::config 'debug')"
 
 if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
@@ -13,6 +12,7 @@ fi
 export NO_SERVE_HTTPS="$(bashio::config 'no_serve_https')"
 
 CONFIG_PATH=/data/config/diyhue
+
 
 if [[ -d $CONFIG_PATH ]]; then
     echo "$CONFIG_PATH exists."


### PR DESCRIPTION
**EDIT: UPDATED**

I have now found the location of the diyhue config folder - it sits in a folder called diyhue alongside the Home Assistant configuration.yaml. As such I've made this PR only "no server https"


**ORIGINAL PR comment**

So this PR does two things.

1) removes the config_dir from the configuration options instead we use `/data/config/diyhue`. `/data` is the hassio persisted storage (/usr/share/hassio/addons/data/457625a0_diyhue-beta/config/diyhue) this means you can then access it on your host system in... `/usr/share/hassio/addons/data/457625a0_diyhue-beta/config/diyhue`

2) Add a config option `no_serve_https` this will stop diyhue starting a web server on port 443 which stops the `OSError: [Errno 98] Address in use` error if you run your home assistant on port 443

I made the changes initially to the diyHue-beta area but didn't realise that wasn't the one that the addon repo loads so I've put these changes in both.