### PR TITLE
Don't use host network

### DIFF
--- a/diyhue-flask/config.json
+++ b/diyhue-flask/config.json
@@ -25,7 +25,7 @@
 	"auth_api": true,
 	"hassio_api": true,
 	"hassio_role": "default",
-	"host_network": true,
+	"host_network": false,
 	"uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {

--- a/diyhue-flask/config.json
+++ b/diyhue-flask/config.json
@@ -25,7 +25,6 @@
 	"auth_api": true,
 	"hassio_api": true,
 	"hassio_role": "default",
-	"host_network": false,
 	"uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {

--- a/diyhue/config.json
+++ b/diyhue/config.json
@@ -25,7 +25,7 @@
 	"auth_api": true,
 	"hassio_api": true,
 	"hassio_role": "default",
-	"host_network": true,
+	"host_network": false,
 	"uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {

--- a/diyhue/config.json
+++ b/diyhue/config.json
@@ -25,7 +25,6 @@
 	"auth_api": true,
 	"hassio_api": true,
 	"hassio_role": "default",
-	"host_network": false,
 	"uart": true,
 	"map": ["config:rw", "share:rw"],
 	"options": {


### PR DESCRIPTION
Don't use host network as we don't need it as the ports we need are forwarded on. This removes issues with ports clashing with other services and also allows diyhue to be proxied properly using nginx addon.