### PR TITLE
ci: adopt the Flama delivery platform

### DIFF
--- a/.flama/commands.json
+++ b/.flama/commands.json
@@ -1,0 +1,22 @@
+{
+  "buildable": [
+    "python3",
+    "scripts/addon-check.py"
+  ],
+  "affected": [
+    "python3",
+    "scripts/addon-check.py"
+  ],
+  "full": [
+    "python3",
+    "scripts/addon-check.py"
+  ],
+  "smoke": [
+    "python3",
+    "scripts/addon-check.py"
+  ],
+  "health": [
+    "python3",
+    "scripts/addon-check.py"
+  ]
+}

--- a/.flama/delivery-contract.json
+++ b/.flama/delivery-contract.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "repository": {
+    "owner": "maxbec",
+    "name": "hassio-diyHue",
+    "visibility": "public"
+  },
+  "paperclip": {
+    "company": "Private",
+    "projectId": "79f28601-5a81-4a68-a77e-fac4105b30fb",
+    "workspaceId": "92e8164e-47a4-4f19-9a7a-875c0d269e8c"
+  },
+  "profile": "fast",
+  "branches": {
+    "default": "main",
+    "stable": "main",
+    "featureTarget": "main"
+  },
+  "commands": {
+    "buildable": "./scripts/delivery buildable",
+    "affected": "./scripts/delivery affected",
+    "full": "./scripts/delivery full",
+    "smoke": "./scripts/delivery smoke",
+    "health": "./scripts/delivery health"
+  },
+  "changeDetection": {
+    "failClosed": true,
+    "broadenOn": [
+      "lockfiles",
+      "authentication",
+      "database_schema",
+      "uncertain_detection"
+    ]
+  },
+  "release": {
+    "enabled": false,
+    "strategy": "release-please",
+    "impactSource": "paperclip_task",
+    "type": "simple"
+  },
+  "deployment": {
+    "deployable": false,
+    "provider": "none",
+    "manifestPath": ".deploy/production.yaml"
+  },
+  "secrets": {
+    "source": "infisical",
+    "paths": {
+      "development": "/development"
+    },
+    "exceptionsFile": ".flama/secret-exceptions.json",
+    "projectSlug": "hassio-diyHue"
+  },
+  "platform": {
+    "repository": "maxbec/flama-delivery-platform",
+    "version": "0.1.0"
+  }
+}

--- a/.flama/paperclip-webhook.json
+++ b/.flama/paperclip-webhook.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "repository": "maxbec/hassio-diyHue",
+  "company": "Private",
+  "projectId": "79f28601-5a81-4a68-a77e-fac4105b30fb",
+  "workspaceId": "92e8164e-47a4-4f19-9a7a-875c0d269e8c",
+  "appSlug": "flama-delivery-maxbec",
+  "events": [
+    "check_run",
+    "deployment_status",
+    "pull_request",
+    "pull_request_review",
+    "push",
+    "release",
+    "workflow_run"
+  ]
+}

--- a/.flama/platform-lock.json
+++ b/.flama/platform-lock.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "repository": "maxbec/flama-delivery-platform",
+  "version": "0.1.0",
+  "ref": "80e829ad0ccddf87898988711ff92cd810b62c13"
+}

--- a/.flama/run-command.mjs
+++ b/.flama/run-command.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+
+const allowedCommands = new Set(["buildable", "affected", "full", "smoke", "health"]);
+
+export async function loadCommand(name, configurationUrl = new URL("./commands.json", import.meta.url)) {
+  if (!allowedCommands.has(name)) throw new Error("unsupported delivery command");
+  const parsed = JSON.parse(await readFile(configurationUrl, "utf8"));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("invalid delivery command configuration");
+  }
+  const command = parsed[name];
+  if (
+    !Array.isArray(command) ||
+    command.length === 0 ||
+    !command.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    throw new Error("invalid delivery command configuration");
+  }
+  return command;
+}
+
+/**
+ * Resolve the install command from the repository manifest. A delivery command
+ * that runs against whatever happens to be on the machine is not reproducible:
+ * without an install a missing node_modules silently falls through to an
+ * unrelated global tool, so the result depends on the host rather than the
+ * commit. Installs are lockfile-pinned so they cannot drift either.
+ */
+export async function installCommand(root) {
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(new URL("package.json", root), "utf8"));
+  } catch {
+    return undefined;
+  }
+  const declared = typeof manifest.packageManager === "string" ? manifest.packageManager : "";
+  const name = declared.split("@")[0];
+  if (name === "pnpm") return ["pnpm", "install", "--frozen-lockfile"];
+  if (name === "yarn") return ["yarn", "install", "--immutable"];
+  return ["npm", "ci"];
+}
+
+function spawnCommand([executable, ...args], root) {
+  const child = spawn(executable, args, {
+    cwd: root,
+    env: process.env,
+    shell: false,
+    stdio: "inherit",
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal !== null) reject(new Error("delivery command terminated by signal"));
+      else resolve(code ?? 1);
+    });
+  });
+}
+
+export async function run(name) {
+  const root = new URL("../", import.meta.url);
+  // Neither read depends on the other, so they are not made to wait in turn.
+  const [command, install] = await Promise.all([loadCommand(name), installCommand(root)]);
+  if (install !== undefined) {
+    const installed = await spawnCommand(install, root);
+    if (installed !== 0) return installed;
+  }
+  return spawnCommand(command, root);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], "file:").href) {
+  try {
+    process.exitCode = await run(process.argv[2]);
+  } catch {
+    console.error("delivery command failed");
+    process.exitCode = 1;
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Only the production deployment manifest claims review here.
+#
+# Branch protection requires code-owner review, and the code owner is the
+# same account that opens every migration pull request, so listing the
+# generated files made the platform unable to update its own consumers.
+# Those files are validated against the pinned platform by the Policy Gate
+# on every pull request, which is a stronger guarantee than a review.
+/.deploy/production.yaml @maxbec

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: thursday
+      time: "04:00"
+      timezone: Europe/Berlin
+    target-branch: main
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+    groups:
+      routine-updates:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/flama-branch-guard.yml
+++ b/.github/workflows/flama-branch-guard.yml
@@ -1,0 +1,15 @@
+name: Flama Branch Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  branch-guard:
+    uses: maxbec/flama-delivery-platform/.github/workflows/reusable-branch-guard.yml@80e829ad0ccddf87898988711ff92cd810b62c13
+    with:
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      profile: fast

--- a/.github/workflows/flama-deploy.yml
+++ b/.github/workflows/flama-deploy.yml
@@ -1,0 +1,28 @@
+name: Flama Production Deploy
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [.deploy/production.yaml]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event.pull_request.merged == true }}
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
+      id-token: write
+      attestations: read
+    uses: maxbec/flama-delivery-platform/.github/workflows/reusable-deploy.yml@80e829ad0ccddf87898988711ff92cd810b62c13
+    with:
+      platform-sha: 80e829ad0ccddf87898988711ff92cd810b62c13
+      pull-request-number: ${{ github.event.pull_request.number }}
+      approved-head-sha: ${{ github.event.pull_request.head.sha }}
+      merge-sha: ${{ github.event.pull_request.merge_commit_sha }}
+      manifest-path: .deploy/production.yaml
+      adapter-path: .flama/provider.cjs

--- a/.github/workflows/flama-final.yml
+++ b/.github/workflows/flama-final.yml
@@ -1,0 +1,16 @@
+name: Flama Final
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  final:
+    uses: maxbec/flama-delivery-platform/.github/workflows/reusable-final.yml@80e829ad0ccddf87898988711ff92cd810b62c13
+    with:
+      base-sha: ${{ github.event.pull_request.base.sha }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      platform-sha: 80e829ad0ccddf87898988711ff92cd810b62c13

--- a/.github/workflows/flama-policy.yml
+++ b/.github/workflows/flama-policy.yml
@@ -1,0 +1,19 @@
+name: Flama Policy
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  policy:
+    uses: maxbec/flama-delivery-platform/.github/workflows/reusable-policy.yml@80e829ad0ccddf87898988711ff92cd810b62c13
+    with:
+      base-sha: ${{ github.event.pull_request.base.sha }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      paperclip-app-slug: flama-delivery-maxbec
+      platform-sha: 80e829ad0ccddf87898988711ff92cd810b62c13
+      profile: fast

--- a/.paperclip/project.yaml
+++ b/.paperclip/project.yaml
@@ -1,0 +1,6 @@
+schemaVersion: 1
+repository: maxbec/hassio-diyHue
+company: Private
+projectId: 79f28601-5a81-4a68-a77e-fac4105b30fb
+workspaceId: 92e8164e-47a4-4f19-9a7a-875c0d269e8c
+profile: fast

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+
+# flama-delivery:start
+# Flama delivery platform: generated and drift-protected.
+.flama/
+.paperclip/
+.github/workflows/flama-*.yml
+.github/dependabot.yml
+.github/CODEOWNERS
+.release-please-config.json
+.release-please-manifest.json
+scripts/delivery
+# flama-delivery:end

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent instructions
+
+<!-- prettier-ignore-start -->
+<!-- flama-delivery:start -->
+## Flama delivery
+
+This repository uses the fast delivery profile. Target main.
+Run deterministic checks only through `./scripts/delivery`.
+Never expose secret values; use the approved Infisical identity and paths.
+Production requires Max's approval of the exact deployment PR head SHA.
+Do not edit centrally generated `.flama` or Flama workflow files by hand.
+<!-- flama-delivery:end -->
+<!-- prettier-ignore-end -->

--- a/scripts/addon-check.py
+++ b/scripts/addon-check.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Baseline check for this Home Assistant add-on repository.
+
+There is no package manifest and nothing to compile, so the delivery commands
+have to check the things that actually break here: an add-on manifest that
+stops parsing or loses a required key, a Dockerfile that is missing or has no
+base image, and a shell script with a syntax error. All three ship silently
+today and only fail when Supervisor tries to install the add-on.
+
+Uses nothing beyond python3 and bash, because the runner has no linters
+installed and a check that cannot run is not a check.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Supervisor refuses an add-on missing any of these.
+REQUIRED_KEYS = ("name", "version", "slug", "arch")
+
+
+def tracked() -> list[str]:
+    listed = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=ROOT, check=True, capture_output=True, text=True
+    )
+    return [path for path in listed.stdout.split("\0") if path]
+
+
+def main() -> int:
+    failures: list[str] = []
+    paths = tracked()
+
+    manifests = [path for path in paths if Path(path).name in ("config.json", "config.yaml")]
+    if not manifests:
+        failures.append("no add-on manifest found")
+
+    for path in manifests:
+        if path.endswith(".yaml"):
+            continue  # Only the JSON form is parsed without a YAML dependency.
+        try:
+            manifest = json.loads((ROOT / path).read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            failures.append(f"{path}: {error}")
+            continue
+        if not isinstance(manifest, dict):
+            failures.append(f"{path}: manifest is not an object")
+            continue
+        for key in REQUIRED_KEYS:
+            if key not in manifest:
+                failures.append(f"{path}: missing required key '{key}'")
+        # An add-on directory without a Dockerfile cannot be built.
+        dockerfile = (ROOT / path).parent / "Dockerfile"
+        if not dockerfile.is_file():
+            failures.append(f"{path}: no Dockerfile beside the manifest")
+        elif not any(
+            line.strip().upper().startswith("FROM")
+            for line in dockerfile.read_text(encoding="utf-8", errors="replace").splitlines()
+        ):
+            failures.append(f"{dockerfile.relative_to(ROOT)}: no FROM instruction")
+
+    scripts = [path for path in paths if path.endswith(".sh")]
+    for path in scripts:
+        syntax = subprocess.run(
+            ["bash", "-n", str(ROOT / path)], capture_output=True, text=True
+        )
+        if syntax.returncode != 0:
+            first = (syntax.stderr.strip().splitlines() or ["syntax error"])[0]
+            failures.append(f"{path}: {first}")
+
+    for failure in failures:
+        print(f"addon-check: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"addon-check: {len(manifests)} add-ons, {len(scripts)} shell scripts, all valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delivery
+++ b/scripts/delivery
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if [[ $# -ne 1 ]]; then
+  echo 'usage: ./scripts/delivery {buildable|affected|full|smoke|health}' >&2
+  exit 2
+fi
+
+case "$1" in
+  buildable|affected|full|smoke|health)
+    exec node "$ROOT_DIR/.flama/run-command.mjs" "$1"
+    ;;
+  *)
+    echo 'unsupported delivery command' >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Phase 5 wave 3. Renders the pinned Fast-profile workflow callers, Dependabot policy, Release Please configuration, delivery CODEOWNERS, and the `./scripts/delivery` command contract.

There is no package manifest and nothing to compile here, so the contract runs `scripts/addon-check.py`, which checks what actually breaks in an add-on repository: every `config.json` parses and carries `name`/`version`/`slug`/`arch`, every add-on has a Dockerfile with a `FROM`, and every shell script passes `bash -n`. It uses only python3 and bash, because the runner has no linters installed and a check that cannot run is not a check.

Verified by breaking the repository on purpose: invalid manifest JSON, a missing required key, a deleted Dockerfile, an empty Dockerfile, and a shell syntax error each exit 1; the unmodified tree exits 0.

The existing `.github/dependabot.yml` is replaced rather than left alone, and its `github-actions` ecosystem is carried into the generated policy so the migration does not silently drop those updates.