### PR TITLE
ci: pin every cross-repository action to a full commit SHA

### DIFF
--- a/.github/workflows/ha-lint.yml
+++ b/.github/workflows/ha-lint.yml
@@ -6,12 +6,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⤵️ Check out code from GitHub
-              uses: actions/checkout@v2.3.4
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
             - name: 🚀 Run Home Assistant Add-on Lint
-              uses: frenck/action-addon-linter@v2.2
+              uses: frenck/action-addon-linter@ca747f8ea5ea80169eb39c62b10b0d6a517690c4 # v2.2
               with:
                   path: "./diyhue"
             - name: 🚀 Run Home Assistant Add-on Lint for BETA
-              uses: frenck/action-addon-linter@v2.2
+              uses: frenck/action-addon-linter@ca747f8ea5ea80169eb39c62b10b0d6a517690c4 # v2.2
               with:
                   path: "./diyhue-beta"


### PR DESCRIPTION
A floating tag is a mutable input to a job that holds repository write access. The policy audit reads a reference as pinned only when it ends in forty hex characters, so this repository has reported `actions_trust_policy_drift` for as long as it has been migrated.

The tag stays as a trailing comment — that is what Dependabot's github-actions ecosystem reads when it moves a pin forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)