### PR TITLE
fix(build): pin each add-on to an upstream revision it can actually build

### DIFF
--- a/diyhue-beta/Dockerfile
+++ b/diyhue-beta/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILD_ARCHI = ${BUILD_ARCH}
 
 # Other settings
 ENV LANG C.UTF-8
-ENV DIYHUE_VERSION=master
+ENV DIYHUE_VERSION=54d0d1577dd17978dd4bbf6b079ee357992818f8
 ENV WORKING_DIR=/opt/hue-emulator
 
 # Create the needed folders
@@ -22,7 +22,7 @@ RUN mkdir diyhue config ${WORKING_DIR}
 RUN apk add -q -u python3 openssl nmap psmisc iproute2 alpine-sdk build-base
 
 # Download diyhue and untar it
-RUN curl -J -L -o $diyhue.tar.gz "https://github.com/diyhue/diyHue/archive/refs/heads/beta.tar.gz" \
+RUN curl -J -L -o $diyhue.tar.gz "https://github.com/diyhue/diyHue/archive/${DIYHUE_VERSION}.tar.gz" \
 	&& tar xzvf $diyhue.tar.gz --strip-components=1 -C diyhue \
 	&& rm -rf $diyhue.tar.gz \
 	&& pip3 install -r /diyhue/requirements.txt --no-cache-dir

--- a/diyhue/Dockerfile
+++ b/diyhue/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILD_ARCHI = ${BUILD_ARCH}
 
 # Other settings
 ENV LANG C.UTF-8
-ENV DIYHUE_VERSION=master
+ENV DIYHUE_VERSION=0f8599b1e06597488fb0e301a42cf0b641abf37f
 ENV WORKING_DIR=/opt/hue-emulator
 
 # Create the needed folders
@@ -22,7 +22,7 @@ RUN mkdir diyhue config ${WORKING_DIR}
 RUN apk add -q -u python3 openssl nmap psmisc iproute2 alpine-sdk build-base
 
 # Download diyhue and untar it
-RUN curl -J -L -o $diyhue.tar.gz "https://github.com/diyhue/diyHue/archive/refs/heads/master.tar.gz" \
+RUN curl -J -L -o $diyhue.tar.gz "https://github.com/diyhue/diyHue/archive/${DIYHUE_VERSION}.tar.gz" \
 	&& tar xzvf $diyhue.tar.gz --strip-components=1 -C diyhue \
 	&& rm -rf $diyhue.tar.gz \
 	&& pip3 install -r /diyhue/requirements.txt --no-cache-dir


### PR DESCRIPTION
Both add-ons fetched a moving upstream branch at build time, so neither build was reproducible and both had drifted until they no longer worked.

**Stable** failed at `mv /diyhue/BridgeEmulator/web-ui/` — upstream restructured in March 2022 and that directory, `protocols/` and `debug/clip.html` are gone from `master`. Pinned to `0f8599b1` (2021-10-29), the commit immediately before the "Merge beta with master" that removed them, which is the newest revision carrying the layout this Dockerfile expects.

**Beta** could not build at all: it fetched `archive/refs/heads/beta.tar.gz` and there is no `beta` branch upstream any more — that URL 404s. Its Dockerfile expects the newer layout (`HueObjects/`, `configManager/`, `flaskUI/`, `lights/`), which is what `master` carries today, so it is pinned to master's current head.

Both now fetch `archive/${DIYHUE_VERSION}.tar.gz`, so the pin alone decides what gets built.

## Verification

Built both images locally for amd64 against `hassioaddons/base-python:5.3.4`. Both succeed; before this change both failed.

## Note for advancing the stable pin

Stable now explicitly tracks a 2021 upstream revision. Moving it forward is a **port**, not a version bump — the layout, the removed `protocols/` module, and the coap-client binaries `select.sh` expects all changed in that merge.